### PR TITLE
CORCI-938 build: Resolving hdf5-devel install on Leap 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ test:
 	$(call install_repos,$(NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
 	yum -y install $(NAME) java-$(NAME) $(NAME)-devel $(NAME)-static $(NAME)-tests
 	yum -y install mpich-devel
-	yum -y $(NAME)-mpich $(NAME)-mpich-devel $(NAME)-mpich-static
+	yum -y install $(NAME)-mpich $(NAME)-mpich-devel $(NAME)-mpich-static

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,18 @@ hdf5comp:
 
 %.patch:
 	curl -f -L -O https://src.fedoraproject.org/rpms/hdf5/raw/master/f/$@
+
+test:
+	$(call install_repos,$(NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
+	yum -y install \
+	  $(NAME) \
+	  java-$(NAME) \
+	  $(NAME)-devel \
+	  $(NAME)-static \
+	  $(NAME)-mpich \
+	  $(NAME)-mpich-devel \
+	  $(NAME)-mpich-static \
+	  $(NAME)-openmpi \
+	  $(NAME)-openmpi-devel \
+	  $(NAME)-openmpi-static \
+	  $(NAME)-tests

--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,6 @@ hdf5comp:
 
 test:
 	$(call install_repos,$(NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
-	yum -y install \
-	  $(NAME) \
-	  java-$(NAME) \
-	  $(NAME)-devel \
-	  $(NAME)-static \
-	  $(NAME)-mpich \
-	  $(NAME)-mpich-devel \
-	  $(NAME)-mpich-static \
-	  $(NAME)-tests
+	yum -y install $(NAME) java-$(NAME) $(NAME)-devel $(NAME)-static $(NAME)-tests
+	yum -y install mpich-devel
+	yum -y $(NAME)-mpich $(NAME)-mpich-devel $(NAME)-mpich-static

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,4 @@ test:
 	  $(NAME)-mpich \
 	  $(NAME)-mpich-devel \
 	  $(NAME)-mpich-static \
-	  $(NAME)-openmpi \
-	  $(NAME)-openmpi-devel \
-	  $(NAME)-openmpi-static \
 	  $(NAME)-tests

--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,3 @@ hdf5comp:
 test:
 	$(call install_repos,$(NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
 	yum -y install $(NAME) java-$(NAME) $(NAME)-devel $(NAME)-static $(NAME)-tests
-	yum -y install $(NAME)-mpich $(NAME)-mpich-devel $(NAME)-mpich-static

--- a/Makefile
+++ b/Makefile
@@ -17,5 +17,4 @@ hdf5comp:
 test:
 	$(call install_repos,$(NAME)@$(BRANCH_NAME):$(BUILD_NUMBER))
 	yum -y install $(NAME) java-$(NAME) $(NAME)-devel $(NAME)-static $(NAME)-tests
-	yum -y install mpich-devel
 	yum -y install $(NAME)-mpich $(NAME)-mpich-devel $(NAME)-mpich-static

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -131,9 +131,9 @@ HDF5 static libraries.
 %package mpich
 Summary: HDF5 mpich libraries
 %if (0%{?suse_version} >= 1500)
-Requires: mpich-3.0-devel%{?_isa}
+Requires: mpich-3.0-devel
 %else
-Requires: mpich-devel%{?_isa}
+Requires: mpich-devel
 %endif
 Provides: %{name}-mpich2 = %{version}-%{release}
 Obsoletes: %{name}-mpich2 < 1.8.11-4
@@ -577,7 +577,7 @@ done
 
 
 %changelog
-* Fri Jun 19 2020 Phil Henderson <pjillip.henderson@intel.com> - 1.10.5-8.g07066a381e
+* Fri Jun 19 2020 Phil Henderson <phillip.henderson@intel.com> - 1.10.5-8.g07066a381e
 - Fix Leap 15 build of %{name}-devel
 
 * Wed Jan 22 2020 Brian J. Murrell <brian.murrell@intel.com> - 1.10.5-7.g07066a381e

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -283,7 +283,7 @@ do
   mkdir $mpi
   pushd $mpi
 %if (0%{?suse_version} >= 1500)
-  module load gnu-mpich/3.3
+  module load gnu-mpich
 %else
   module load mpi/$mpi-%{_arch}
 %endif

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -144,7 +144,11 @@ Summary: HDF5 mpich development files
 Requires: %{name}-mpich%{?_isa} = %{version}-%{release}
 Requires: libaec-devel%{?_isa}
 Requires: zlib-devel%{?_isa}
+%if (0%{?suse_version} >= 1500)
+Requires: mpich-3.0-devel%{?_isa}
+%else
 Requires: mpich-devel%{?_isa}
+%endif
 Provides: %{name}-mpich2-devel = %{version}-%{release}
 Obsoletes: %{name}-mpich2-devel < 1.8.11-4
 

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -11,7 +11,7 @@
 # You need to recompile all users of HDF5 for each version change
 Name: hdf5
 Version: 1.10.5
-Release: 7.g07066a381e%{?dist}
+Release: 8.g07066a381e%{?dist}
 Summary: A general purpose library and file format for storing scientific data
 License: BSD
 URL: https://portal.hdfgroup.org/display/HDF5/HDF5
@@ -130,7 +130,11 @@ HDF5 static libraries.
 %if %{with_mpich}
 %package mpich
 Summary: HDF5 mpich libraries
-BuildRequires: mpich-devel
+%if (0%{?suse_version} >= 1500)
+Requires: mpich-3.0-devel%{?_isa}
+%else
+Requires: mpich-devel%{?_isa}
+%endif
 Provides: %{name}-mpich2 = %{version}-%{release}
 Obsoletes: %{name}-mpich2 < 1.8.11-4
 Provides: %{name}-mpich2-cart-%{cart_major}-daos-%{daos_major}
@@ -573,6 +577,9 @@ done
 
 
 %changelog
+* Fri Jun 19 2020 Phil Henderson <pjillip.henderson@intel.com> - 1.10.5-8.g07066a381e
+- Fix Leap 15 build of %{name}-devel
+
 * Wed Jan 22 2020 Brian J. Murrell <brian.murrell@intel.com> - 1.10.5-7.g07066a381e
 - Port to Leap 15.1
 

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -130,11 +130,7 @@ HDF5 static libraries.
 %if %{with_mpich}
 %package mpich
 Summary: HDF5 mpich libraries
-%if (0%{?suse_version} >= 1500)
-Requires: mpich-3.0-devel
-%else
-Requires: mpich-devel
-%endif
+BuildRequires: mpich-devel
 Provides: %{name}-mpich2 = %{version}-%{release}
 Obsoletes: %{name}-mpich2 < 1.8.11-4
 Provides: %{name}-mpich2-cart-%{cart_major}-daos-%{daos_major}

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -144,11 +144,7 @@ Summary: HDF5 mpich development files
 Requires: %{name}-mpich%{?_isa} = %{version}-%{release}
 Requires: libaec-devel%{?_isa}
 Requires: zlib-devel%{?_isa}
-%if (0%{?suse_version} >= 1500)
-Requires: mpich-3.0-devel%{?_isa}
-%else
 Requires: mpich-devel%{?_isa}
-%endif
 Provides: %{name}-mpich2-devel = %{version}-%{release}
 Obsoletes: %{name}-mpich2-devel < 1.8.11-4
 

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -317,7 +317,7 @@ mv %{buildroot}%{_includedir}/*.mod %{buildroot}%{_fmoddir}
 for mpi in %{?mpi_list}
 do
 %if (0%{?suse_version} >= 1500)
-  module load gnu-mpich/3.3
+  module load gnu-mpich
 %else
   module load mpi/$mpi-%{_arch}
 %endif
@@ -395,7 +395,7 @@ export OMPI_MCA_rmaps_base_oversubscribe=1
 for mpi in %{?mpi_list}
 do
 %if (0%{?suse_version} >= 1500)
-  module load gnu-mpich/3.3
+  module load gnu-mpich
 %else
   module load mpi/$mpi-%{_arch}
 %endif

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -101,7 +101,11 @@ Summary: HDF5 development files
 Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: libaec-devel%{?_isa}
 Requires: zlib-devel%{?_isa}
+%if (0%{?suse_version} >= 1500)
+Requires: gcc-fortran%{?_isa}
+%else
 Requires: gcc-gfortran%{?_isa}
+%endif
 
 %description devel
 HDF5 development headers and libraries.


### PR DESCRIPTION
As part of adding a MACSio RPM, the hdf5-devel RPM is required and
currently fails to install on Leap 15 due to an incorrect requirement.
These changes resolve the requirement issue and also add testing the
installation of all the built hdf5 RPMs.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>