### PR TITLE
DAOS-5321 hdf5: update hdf5 version

### DIFF
--- a/daos.patch
+++ b/daos.patch
@@ -29,18 +29,6 @@ index 69b66aefc..ab9914ff9 100644
  
      ndsets_params.name = PARATESTFILE;
      ndsets_params.count = ndatasets;
-@@ -419,8 +422,11 @@ int main(int argc, char **argv)
- #else
-     printf("big dataset test will be skipped on Windows (JIRA HDDFV-8064)\n");
- #endif
-+/** MSC - default fill value of 0 does not work with DAOS */
-+#ifdef DAOS_UNSUPPORTED
-     AddTest("fill", dataset_fillvalue, NULL,
-       "dataset fill value", PARATESTFILE);
-+#endif
- 
-     AddTest("cchunk1",
-   coll_chunk1,NULL, "simple collective chunk io",PARATESTFILE);
 @@ -532,6 +538,8 @@ int main(int argc, char **argv)
      AddTest((mpi_size < 2)? "-fiodc" : "fiodc", file_image_daisy_chain_test, NULL,
              "file image ops daisy chain", NULL);

--- a/hdf5.spec
+++ b/hdf5.spec
@@ -28,7 +28,6 @@ Patch2: hdf5-warning.patch
 # Fix java build
 Patch3: hdf5-build.patch
 # Disable tests that don't work with DAOS
-Patch10: hdf5-1.10.5-11.4-g07066a381e.patch
 Patch11: daos.patch
 
 %if (0%{?suse_version} >= 1500)
@@ -205,7 +204,6 @@ HDF5 tests
 
 %prep
 %setup -q -a 2 -n %{name}-%{version}%{?snaprel}
-%patch10 -p1 -b .hdf5-1.10.5-11.4-g07066a381e
 %patch0 -p1 -b .LD_LIBRARY_PATH
 #patch1 -p1 -b .mpi
 %patch2 -p1 -b .warning


### PR DESCRIPTION
HDF5 version used should be 1.10 and not 1.11.
also enable HDF5 fill value tests as they are supported now

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>